### PR TITLE
PyQt5 to PyQt6

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,16 +14,17 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
-          - macos-11
+          - ubuntu-latest
+          - macos-15
           - windows-2022
         python-version:
-          - '3.8'
+          - '3.12'
     steps:
       - name: 'Install Packages'
         run: |
           if [ "${{ runner.os }}" == "Linux" ]; then
-            sudo apt-get install -yq x11-utils libxkbcommon-x11-0 libfuse2
+            sudo apt-get update
+            sudo apt-get install -yq x11-utils libxkbcommon-x11-0 libfuse2t64
           elif [ "${{ runner.os }}" == "macOS" ]; then
             brew install create-dmg
           elif [ "${{ runner.os }}" == "Windows" ]; then
@@ -34,39 +35,16 @@ jobs:
           fi
         shell: bash
       - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: pip3 install --upgrade pip
-      - run: pip3 install -r requirements.txt
-      - run: pip3 freeze
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r requirements.txt
+      - run: python -m pip freeze
       - run: python3 pack.py || python pack.py
-      - name: 'Before deploy'
-        run: |
-          if [ "${{ runner.os }}" == "Linux" ]; then
-            export GLIBC_VER=$(ldd --version | grep ldd | awk '{ print $NF }')
-            mv "dist/kflash_gui.tar.xz" "dist/kflash_gui_${{ github.ref_name }}_linux_glibc${GLIBC_VER}.tar.xz"
-            mkdir -p "dist/AppDir/usr/bin"
-            cp -rf "dist/kflash_gui" "dist/AppDir/usr/bin/kflash_gui"
-            mkdir -p "dist/AppDir/usr/share/icons/hicolor/128x128/apps"
-            cp -rf "kflash_gui_data/assets/logo.png" "dist/AppDir/usr/share/icons/hicolor/128x128/apps/kflash_gui.png"
-            mkdir -p "dist/AppDir/usr/share/applications"
-            cp -rf "kflash_gui_data/application/kflash_gui.desktop" "dist/AppDir/usr/share/applications/kflash_gui.desktop"
-            wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage && chmod +x linuxdeploy-x86_64.AppImage
-            pushd "dist" && ../linuxdeploy-x86_64.AppImage --appimage-extract-and-run --appdir "AppDir" --output appimage && popd
-            LD_LIBRARY_PATH='' find dist/AppDir -type f -exec ldd {} 2>&1 \; | grep '=>' | grep -v AppDir
-            ls -l "dist"
-            mv dist/*.AppImage "dist/kflash_gui_${{ github.ref_name }}_linux_glibc${GLIBC_VER}.AppImage"
-          elif [ "${{ runner.os }}" == "macOS" ]; then
-            mv "dist/kflash_gui.dmg" "dist/kflash_gui_${{ github.ref_name }}_macOS.dmg"
-          elif [ "${{ runner.os }}" == "Windows" ]; then
-            mv "dist/kflash_gui.7z" "dist/kflash_gui_${{ github.ref_name }}_windows.7z"
-          else
-            echo "${{ runner.os }} not supported"
-            exit 1
-          fi
-          find dist
+      - name: 'List build output'
+        run: ls -l dist
         shell: bash

--- a/Combobox.py
+++ b/Combobox.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QComboBox,QListView
-from PyQt5.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QComboBox, QListView
+from PyQt6.QtCore import pyqtSignal
 
 
 class ComboBox(QComboBox):

--- a/helpAbout.py
+++ b/helpAbout.py
@@ -26,7 +26,7 @@ def strAbout():
 <br>
 <b>'''+tr("About")+''':</b>
 <br><br>
-'''+tr("Release with")+" Python" +str(py_version[0]+py_version[1]/10)+ ''' + PyQt5<br><br>
+'''+tr("Release with")+" Python" +str(py_version[0]+py_version[1]/10)+ ''' + PyQt6<br><br>
 <div><div>'''+parameters.appName+" "+tr("is a Open source project created by")+''' </div><a style="vertical-align: middle;" href="http://www.sipeed.com"><img src="'''+strPath+"/"+parameters.appLogo2+'''" width=109 height=32></img></a><br></div>
 ''' +tr("Author")+":"+parameters.author+'''<br><br>
 

--- a/kflash_gui.py
+++ b/kflash_gui.py
@@ -10,12 +10,13 @@ from Combobox import ComboBox
 import json, zipfile, struct, hashlib
 
 # from COMTool.wave import Wave
-from PyQt5.QtCore import pyqtSignal,Qt
-from PyQt5.QtWidgets import (QApplication, QWidget,QToolTip,QPushButton,QMessageBox,QDesktopWidget,QMainWindow,
-                             QVBoxLayout,QHBoxLayout,QGridLayout,QLabel,
-                             QLineEdit,QGroupBox,QSplitter,QFileDialog,QCheckBox,
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (QApplication, QWidget, QToolTip, QPushButton, QMessageBox, QMainWindow,
+                             QVBoxLayout, QHBoxLayout, QGridLayout, QLabel,
+                             QLineEdit, QGroupBox, QFileDialog, QCheckBox,
                              QProgressBar)
-from PyQt5.QtGui import QIcon,QFont,QTextCursor,QPixmap
+from PyQt6.QtGui import QIcon, QFont, QPixmap
+
 import serial
 import serial.tools.list_ports
 import threading
@@ -381,7 +382,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle(parameters.appName+" V"+str(helpAbout.versionMajor)+"."+str(helpAbout.versionMinor))
         icon = QIcon()
         print("icon path:"+self.DataPath+"/"+parameters.appIcon)
-        icon.addPixmap(QPixmap(self.DataPath+"/"+parameters.appIcon), QIcon.Normal, QIcon.Off)
+        icon.addPixmap(QPixmap(self.DataPath+"/"+parameters.appIcon), QIcon.Mode.Normal, QIcon.State.Off)
         self.setWindowIcon(icon)
         if sys.platform == "win32":
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(parameters.appName)
@@ -444,10 +445,11 @@ class MainWindow(QMainWindow):
 
     def MoveToCenter(self):
         qr = self.frameGeometry()
-        cp = QDesktopWidget().availableGeometry().center()
+        screen = QApplication.primaryScreen()
+        cp = screen.availableGeometry().center()
         qr.moveCenter(cp)
         self.move(qr.topLeft())
-    
+
     def changeFunc(self):
         if self.burning or self.packing or self.erasing:
             self.hintSignal.emit(tr("Busy"), tr("Busy"))
@@ -579,10 +581,10 @@ class MainWindow(QMainWindow):
         
         self.eraseStatus.setText("<font color=%s>%s</font>" %("#0eb40e", tr("Preparing Erase") ))
         eraseThread = threading.Thread(target=self.eraseProcess, args=(addr, length, config['dev'], config['baud'], config['board'], config['color'], config['slow']))
-        eraseThread.setDaemon(True)
+        eraseThread.daemon = True
         eraseThread.start()
         eraseStatusThread = threading.Thread(target=self.updateEraseStatus, args=(length_text, unit, eraseTimeEstimate))
-        eraseStatusThread.setDaemon(True)
+        eraseStatusThread.daemon = True
         eraseStatusThread.start()
     
     def setEraseButton(self, cancel):
@@ -874,7 +876,7 @@ class MainWindow(QMainWindow):
 
         # pack and save
         t = threading.Thread(target=self.packFileProccess, args=(files, fileName_choose,))
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
     
     def packFileProccess(self, files, fileSaveName):
@@ -975,7 +977,7 @@ class MainWindow(QMainWindow):
 
         # pack and save
         t = threading.Thread(target=self.mergeBinProccess, args=(files, fileName_choose,))
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
     
     def mergeBinProccess(self, files, fileSaveName):
@@ -1060,7 +1062,7 @@ class MainWindow(QMainWindow):
         if not self.isDetectSerialPort:
             self.isDetectSerialPort = True
             t = threading.Thread(target=self.detectSerialPortProcess)
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
 
     def showCombobox(self):
@@ -1320,7 +1322,7 @@ class MainWindow(QMainWindow):
         self.progressHint.setText(hint)
         # download
         burnThread = threading.Thread(target=self.flashBurnProcess, args=(config['dev'], config['baud'], config['board'], config['sram'], fileType, filesInfo, self.progress, config['color'], config['slow'], config['iomode']))
-        burnThread.setDaemon(True)
+        burnThread.daemon = True
         burnThread.start()
 
     def flashBurnProcess(self, dev, baud, board, sram, fileType, files, callback, color, slow, io_mode):
@@ -1415,10 +1417,9 @@ def main():
     app.setStyleSheet(qss)
     mainWindow.detectSerialPort()
     t = threading.Thread(target=mainWindow.autoUpdateDetect)
-    t.setDaemon(True)
+    t.daemon = True
     t.start()
-    sys.exit(app.exec_())
-
+    sys.exit(app.exec())
 if __name__ == '__main__':
     main()
 

--- a/pack.py
+++ b/pack.py
@@ -11,8 +11,7 @@ if os.path.exists("dist"):
 
 # pyinstaller generate files
 if sys.platform.startswith("win32"):
-    # NOTE: Some stupid antivirus software will kill the generated exe by mistake
-    cmd = 'pyinstaller --onefile --key=stupidantivirus --add-data="kflash_gui_data;kflash_gui_data" --add-binary="kflash_py;kflash_py" -i="kflash_gui_data/assets/logo.ico" -w kflash_gui.py'
+    cmd = 'pyinstaller --onefile --add-data="kflash_gui_data;kflash_gui_data" --add-binary="kflash_py;kflash_py" -i="kflash_gui_data/assets/logo.ico" -w kflash_gui.py'
 elif sys.platform.startswith("darwin"):
     # NOTE: must use --add-data under darwin, or you will get "Unknown Mach-O header" error
     cmd = 'pyinstaller --add-data="kflash_gui_data:kflash_gui_data" --add-data="kflash_py:kflash_py" -i="kflash_gui_data/assets/logo.icns" -w kflash_gui.py'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bs4>=0.0.1
 pyelftools>=0.28
 pyinstaller>=5.1
-PyQt5>=5.15.7
+PyQt6>=6.8.0
 pyserial>=3.5
 requests>=2.28.0
 tinyaes>=1.0.3


### PR DESCRIPTION
Migrate the GUI from PyQt5 to PyQt6.

Supersedes #21. The PyQt5 to PyQt6 commits are the original work of
@jiapei100 (Pei Jia), cherry-picked here with authorship preserved;
all credit for the migration goes to him.

#21 could not go green because its CI matrix pinned Python 3.8 while
PyQt6 >= 6.8 requires Python >= 3.9, and the macos-11 runner is
retired. This PR adds one commit on top to fix the build-test matrix:

- python 3.8 -> 3.12
- macos-11 -> macos-15, ubuntu-22.04 -> ubuntu-latest
- libfuse2 -> libfuse2t64 (noble), checkout@v4, setup-python@v5

Verified locally: deps install and MainWindow constructs under PyQt6
(QIcon.Mode/State, QApplication.primaryScreen, app.exec()).

Closes #21.