### PR TITLE
README.md: fix kfpkg typo in features

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,5 @@
+{
+  // Bilingual README with long URLs and prose; do not hard-wrap at 80.
+  "default": true,
+  "MD013": false
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cross platform GUI wrapper for [kflash.py](https://github.com/sipeed/kflash.py.g
 
 ## Features
 
-* Support `*.bin` and `*.kfpgk` file with file picker
+* Support `*.bin` and `*.kfpkg` file with file picker
 * Support development board select(And auto detect, you should select board manually if you want to use high speed mode)
 * Support select where the firmware burned to
 * Auto scan serial port support
@@ -99,7 +99,7 @@ Refer here: [blog.sipeed.com/p/390.html](http://blog.sipeed.com/p/390.html)
 
 ## 特性
 
-* 支持 `*.bin` 和 `*.kfpgk` 文件， 支持文件选择器选择
+* 支持 `*.bin` 和 `*.kfpkg` 文件， 支持文件选择器选择
 * 支持开发板选择(也支持自动选择, 要使用高速模式尽量手动选择)
 * 可选择程序烧录到 `Flash` 或者 `SRAM`
 * 自动检测电脑上的串口

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # kflash_gui
-=============
 
 Cross platform GUI wrapper for [kflash.py](https://github.com/sipeed/kflash.py.git) (download(/burn) tool for k210)
 
@@ -13,7 +12,7 @@ Cross platform GUI wrapper for [kflash.py](https://github.com/sipeed/kflash.py.g
 * Auto scan serial port support
 * Baudrate editable
 * White skin and night skin support
-* Support Chinese and English Language 
+* Support Chinese and English Language
 * Download(/burn) progress and speed display
 * Cancel download support
 * Support merge bins to one bin file(Especially for factory flash burn usage)
@@ -24,15 +23,15 @@ Cross platform GUI wrapper for [kflash.py](https://github.com/sipeed/kflash.py.g
 
 ## Screenshots
 
-| ![](kflash_gui_data/assets/screenshot_1.png) | ![](kflash_gui_data/assets/screenshot_2.png) |
-| -| -|
-| ![](kflash_gui_data/assets/screenshot_download.png) | ![](kflash_gui_data/assets/screenshot_download_en.png) |
-| ![](kflash_gui_data/assets/screenshot_en.png) | ![](kflash_gui_data/assets/screenshot_file.png) |
-| ![](kflash_gui_data/assets/erase.png) | ![](kflash_gui_data/assets/erase_zh.png)
+| ![main window](kflash_gui_data/assets/screenshot_1.png) | ![settings](kflash_gui_data/assets/screenshot_2.png) |
+| --- | --- |
+| ![download](kflash_gui_data/assets/screenshot_download.png) | ![download English](kflash_gui_data/assets/screenshot_download_en.png) |
+| ![main window English](kflash_gui_data/assets/screenshot_en.png) | ![file picker](kflash_gui_data/assets/screenshot_file.png) |
+| ![erase](kflash_gui_data/assets/erase.png) | ![erase Chinese](kflash_gui_data/assets/erase_zh.png) |
 
 ## Usage
 
-* Download bin file (`kflash_gui_v*.*`)  [here](https://github.com/sipeed/kflash_gui/releases)
+* Download the bin file (`kflash_gui_v*.*`) from the [releases page](https://github.com/sipeed/kflash_gui/releases)
 
 * Compress and double click `kflash_gui.exe` or `kflash_gui`
 
@@ -149,11 +148,3 @@ sudo apt-get install -yq x11-utils libxkbcommon-x11-0 libfuse2
 ## 如何手动打包 `kfpkg`
 
 参考这里: [blog.sipeed.com/p/390.html](http://blog.sipeed.com/p/390.html)
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ sudo pip3 install pyinstaller
 python3 pack.py
 ```
 
+### Raspberry Pi / ARM
+
+There is no prebuilt ARM release: the official PyQt6 arm64 wheels
+require glibc 2.39, which is newer than current Raspberry Pi OS. Run
+from source with the distro's Qt6 package instead of the PyQt6 wheel:
+
+```bash
+sudo apt install python3 python3-pip python3-pyqt6
+pip3 install bs4 pyelftools pyserial requests tinyaes
+python3 kflash_gui.py
+```
+
 ## If something goes wrong
 
 ### If downloading fails


### PR DESCRIPTION
README fixes and docs:

- Fix the package extension typo `*.kfpgk` -> `*.kfpkg` (EN and 中文).
- Fix markdownlint issues: heading blanks, a stray Setext underline,
  trailing spaces, the screenshot table pipe style and image alt text,
  non-descriptive link text, and trailing blank lines.
- Add `.markdownlint.jsonc` disabling MD013 (line-length).
- Document running on Raspberry Pi / ARM from source (no prebuilt ARM
  binary, since PyQt6 arm64 wheels require glibc 2.39).

markdownlint-cli2 reports 0 errors.

Closes: #22
Closes: #18